### PR TITLE
fix: pass correct argument type (string) to query func

### DIFF
--- a/src/features/employee/routes/edit.tsx
+++ b/src/features/employee/routes/edit.tsx
@@ -103,7 +103,7 @@ export default function EmployeeEdit() {
     })
     const {
         data: designations
-    } = useGetDesignationsQuery({ deptId: formik.values.department });
+    } = useGetDesignationsQuery(formik.values.department);
     const {
         data: departments
     } = useGetDepartmentsQuery();


### PR DESCRIPTION
fixes #20 